### PR TITLE
Support W8A8 models in QServe

### DIFF
--- a/kernels/csrc/qgemm/w8a8/gemm_cuda.h
+++ b/kernels/csrc/qgemm/w8a8/gemm_cuda.h
@@ -6,5 +6,5 @@
 // }
 #include <torch/extension.h>
 
-torch::Tensor w8a8_gemm_forward_cuda(torch::Tensor _in_feats, torch::Tensor _kernel, torch::Tensor _wscales, torch::Tensor _ascales);
+void w8a8_gemm_forward_cuda(torch::Tensor _in_feats, torch::Tensor _kernel, torch::Tensor _wscales, torch::Tensor _ascales, torch::Tensor _out_feats);
 

--- a/qserve/engine/arg_utils.py
+++ b/qserve/engine/arg_utils.py
@@ -376,6 +376,9 @@ class EngineArgs:
         if "kv4" in self.precision:
             self.kv_cache_bits = 4
             self.int4_kv = True
+        else:
+            self.kv_cache_bits = 8
+            self.int4_kv = False
         precision = self.precision
         self.kv_zp = True
 

--- a/qserve/modeling/layers/activation.py
+++ b/qserve/modeling/layers/activation.py
@@ -63,7 +63,7 @@ class SiluAndMulQuant(SiluAndMul):
         x: torch.Tensor,
         quantized_mlp_act_buffer: torch.Tensor,
         quantized_scale_buffer: torch.Tensor,
-        quantized_sum_buffer: torch.Tensor,
+        quantized_sum_buffer: torch.Tensor = None,
     ) -> torch.Tensor:
         # quantized_sum_buffer is not used, only to keep the consistency of the interface.
         out = super().forward(x)

--- a/qserve/modeling/layers/layernorm.py
+++ b/qserve/modeling/layers/layernorm.py
@@ -66,7 +66,7 @@ class RMSNormGeneral(nn.Module):
         x: torch.Tensor,
         quantized_hidden_states_buffer: torch.Tensor,
         quantized_scale_buffer: torch.Tensor,
-        quantized_sum_buffer: torch.Tensor,
+        quantized_sum_buffer: torch.Tensor = None,
     ) -> torch.Tensor:
         # quantized_sum_buffer is not used, only to keep the consistency of the interface
         layernorm_ops.rms_norm_general(

--- a/qserve/modeling/layers/quantized_linear/w8a8_linear.py
+++ b/qserve/modeling/layers/quantized_linear/w8a8_linear.py
@@ -90,20 +90,63 @@ class W8A8OF16LinearDynamicInputScale(W8A8OF16LinearStaticScale):
         x: torch.Tensor,
         # [batch * tokens]
         input_scale: torch.Tensor,
-        bias: Optional[torch.Tensor],
-    ) -> torch.Tensor:
+        output_buffer: torch.Tensor,
+    ):
         x_shape = x.shape
         if len(x.shape) > 2:
+            assert 0, "Not implemented"
             x = x.view(-1, x_shape[-1])
-        y = qgemm.w8a8_gemm_forward_cuda(
-            x, self.weight, self.dequant_scale.half(), input_scale.half()
+        qgemm.w8a8_gemm_forward_cuda(
+            x, self.weight, self.dequant_scale.half(), input_scale.half(), output_buffer
         )
         if len(x.shape) > 2:
-            y = y.view(*x_shape[:-1], -1)
-        return y
+            assert 0, "Not implemented 2"
+            output_buffer = output_buffer.view(*x_shape[:-1], -1)
 
-    def forward(self, input_, input_scale):
+    def forward(self, input_, input_scale, output_buffer):
         # Matrix multiply.
-        output = self.apply_weights(input_, input_scale, self.bias)
+        self.apply_weights(input_, input_scale, output_buffer)
         output_bias = self.bias
-        return output, output_bias
+        if output_bias is not None:
+            output_buffer += output_bias
+
+    @classmethod
+    def from_linear(
+        cls,
+        linear,
+        w_bit,
+        init_only=False,
+        s1_scale=None,
+    ):
+        q_linear = cls(
+            linear.in_features,
+            linear.out_features,
+            linear.bias is not None,
+        )
+        if init_only:  # just prepare for loading sd
+            return q_linear
+
+        # need scales and zeros info for real quantization
+        assert s1_scale is not None
+
+        if linear.bias is not None:
+            q_linear.bias = linear.bias.clone().half()
+
+        ## Quantize the weights
+        # Step 1: Quantize the weights to int4
+        linear_weight = linear.weight.data  # OC, IC
+        linear_weight = linear_weight.div_(s1_scale.reshape(linear.out_features, 1).to(linear_weight.device))
+        linear_weight = linear_weight.round_().to(torch.int8)
+
+        assert (
+            linear_weight.min() >= -127 and linear_weight.max() <= 127
+        ), "Quantized weight out of range"
+
+        q_linear.weight.data[:, :] = linear_weight.contiguous()
+
+        # ---- Pack the scales ---- #
+        q_linear.dequant_scale.data[:] = s1_scale.reshape(
+            linear.out_features
+        ).contiguous()
+
+        return q_linear


### PR DESCRIPTION
In this PR, we support W8A8 inference in QServe. The checkpoint converter, model definition, and backend kernels have been modified. 

### Step 1

To run W8A8KV8/KV4 inference with QServe, one needs to first prepare the fake-quantized model with [LMQuant](https://github.com/mit-han-lab/lmquant). The W8A8 quantization is achieved with [SmoothQuant](https://github.com/mit-han-lab/smoothquant), which is also seamlessly supported in LMQuant with one line of [command](https://github.com/mit-han-lab/lmquant/blob/main/projects/llm/scripts/smoothquant.sh).

Note that you may need to add the argument of `--save-model` when running the quantization algorithm. You can find more details [here](https://github.com/mit-han-lab/lmquant/tree/main/projects/llm#usage).

### Step 2

After that, you should convert the fake-quantized checkpoint to the QServe format:

```bash
python checkpoint_converter.py \
--model-path <hf-model-path> \
--quant-path <fake-quant-model-path> \
--group-size -1 --w-bit 8
```

Note that <fake-quant-model-path> is a directory generated by LMQuant in Step 1, including `model.pt` and `scale.pt`. After running the checkpoint_converter, you will get the repacked model under the directory you specified in `checkpoint_converter.py`.

### Step 3
Finally, you will be able to run w8a8 generation, in which `$MODEL_PATH` should be the directory containing packed model your have generated in Step 2:

```bash
python qserve_e2e_generation.py   \
--model $MODEL_PATH  --quant-path $MODEL_PATH \
--ifb-mode  --precision w8a8kv8 --group-size -1
```
 
- Note: We also provide a pre-quantized W8A8 model (Llama-3-8B-Instruct) on [huggingface](https://huggingface.co/mit-han-lab/Llama-3-8B-Instruct-QServe-W8A8/tree/main). If you choose to download the model, you can skip Step 1 & Step 2. 


