### PR TITLE
[FEATURE] add SUPPORTED_ARCH 8.7 to setup.py

### DIFF
--- a/kernels/setup.py
+++ b/kernels/setup.py
@@ -13,7 +13,7 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
 ROOT_DIR = os.path.dirname(__file__)
 
 # Supported NVIDIA GPU architectures.
-SUPPORTED_ARCHS = {"8.0", "8.6", "8.9", "9.0"}
+SUPPORTED_ARCHS = {"8.0", "8.6", "8.7", "8.9", "9.0"}
 
 # Compiler flags.
 CXX_FLAGS = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]


### PR DESCRIPTION
This PR add `8.7` to the `SUPPORTED_ARCHS` in the `setup.py`. This helps compile the kernels for `SM_87` NVIDIA Ampere GPUs like the Jetson AGX Orin (64 GB).