### PR TITLE
[Minor] Fix KV cache block size

### DIFF
--- a/qserve/engine/arg_utils.py
+++ b/qserve/engine/arg_utils.py
@@ -50,7 +50,7 @@ class EngineArgs:
     max_parallel_loading_workers: Optional[int] = None
     block_size: int = 64
     swap_space: int = 4  # GiB
-    gpu_memory_utilization: float = 0.90
+    gpu_memory_utilization: float = 0.75
     max_num_batched_tokens: int = 262144
     max_num_seqs: int = 256
     max_paddings: int = 256

--- a/qserve/worker/cache_engine.py
+++ b/qserve/worker/cache_engine.py
@@ -190,7 +190,7 @@ class CacheEngine:
         key_cache_block = block_size * num_heads * head_size
         value_cache_block = key_cache_block
         total = num_layers * (key_cache_block + value_cache_block)
-        return cache_bit * total
+        return cache_bit * total // 8
 
 
 def _get_dtype_size(dtype: torch.dtype) -> int:


### PR DESCRIPTION
This PR fixes the KV cache block size to reserve the GPU memory it should have.

When I tried to reproduce "TABLE IV" in the QServe paper, the throughput was somewhat saturated before the point shown in the paper, regardless of the batch size. I found this was due to a miscalculation of the number of KV cache blocks. (The unit of the block size would be 'bytes', not 'bits').

Using 90% of free GPU memory sometimes doesn't even leave room for the hidden dimension, so I reduced it to 75%.